### PR TITLE
correcting typo

### DIFF
--- a/Chapter02/image_captioning_pytorch.ipynb
+++ b/Chapter02/image_captioning_pytorch.ipynb
@@ -3982,7 +3982,7 @@
     "    # This line of code turns it into a single tensor of dimensions (<batch_size>, 3, 256, 256)\n",
     "    imgs = torch.stack(imgs, 0)\n",
     " \n",
-    "    # Merge captions (from list of 1D tensors to 2D tensor), similar to merging of images donw above.\n",
+    "    # Merge captions (from list of 1D tensors to 2D tensor), similar to merging of images done above.\n",
     "    cap_lens = [len(cap) for cap in caps]\n",
     "    tgts = torch.zeros(len(caps), max(cap_lens)).long()\n",
     "    for i, cap in enumerate(caps):\n",


### PR DESCRIPTION
Corrected typo 
from this: "# Merge captions (from list of 1D tensors to 2D tensor), similar to merging of images **donw** above."
to this: "# Merge captions (from list of 1D tensors to 2D tensor), similar to merging of images **done** above."
